### PR TITLE
re-add attributes directive (fixes meta tags)

### DIFF
--- a/src/js/directives/attributes.js
+++ b/src/js/directives/attributes.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var angular = require('angular');
+
+module.exports = function(app) {
+  app.directive('attributes', [function() {
+    return {
+      restrict: 'A',
+      scope: {
+        attributes: '='
+      },
+      link: function(scope, element, attr) {
+        scope.$watch('attributes', function(attributes, oldAttributes) {
+          // angular.copy strips keys added by angular, e.g., $$hashKey
+          angular.forEach(angular.copy(oldAttributes), function(_, attribute) {
+            element.removeAttr(attribute);
+          });
+          element.attr(angular.copy(attributes));
+        });
+
+      }
+    };
+  }]);
+};

--- a/src/js/directives/index.js
+++ b/src/js/directives/index.js
@@ -1,5 +1,6 @@
 'use strict';
 module.exports = function(app) {
+  require('./attributes')(app);
   require('./attribution')(app);
   require('./elementPosition')(app);
   require('./elementSize')(app);


### PR DESCRIPTION
The meta tags were not set at all because the `attributes` directive was missing. Without this fix, search engines do not get 404's and cannot use the metadata we provide in the route config.

I stumbled upon this issue while investigating https://github.com/paperhive/paperhive-frontend/issues/274